### PR TITLE
Add gphotos-sync for Google Photos backup

### DIFF
--- a/SETUP_LOG.md
+++ b/SETUP_LOG.md
@@ -1,0 +1,55 @@
+# PC Setup Log
+
+This document logs manual setup steps performed on the system. The goal is to document each step in detail so it can later be automated via Ansible.
+
+---
+
+## Post-Installation Configuration
+
+After running the Ansible playbook, the following manual configurations are required.
+
+### Configure gphotos-sync
+
+gphotos-sync is installed via pipx. You need to authenticate with Google to use it.
+
+1. **Create Google API credentials**
+   - Go to [Google Cloud Console](https://console.cloud.google.com/)
+   - Create a new project (or use existing)
+   - Enable the "Photos Library API"
+   - Go to "Credentials" → "Create Credentials" → "OAuth 2.0 Client ID"
+   - Choose "Desktop application"
+   - Download the JSON file
+
+2. **Setup credentials**
+   ```bash
+   mkdir -p ~/.config/gphotos-sync
+   mv ~/Downloads/client_secret_*.json ~/.config/gphotos-sync/client_secret.json
+   ```
+
+3. **Run first sync to authenticate**
+   ```bash
+   gphotos-sync ~/Pictures/GooglePhotos
+   ```
+   - A browser window will open for Google authentication
+   - Grant access to your Google Photos
+
+4. **Setup automatic sync (optional)**
+   Create a cron job or systemd timer:
+   ```bash
+   crontab -e
+   ```
+   Add:
+   ```
+   0 2 * * * /home/$(whoami)/.local/bin/gphotos-sync ~/Pictures/GooglePhotos
+   ```
+
+#### Automation Notes
+- `client_secret.json` can be stored in Ansible Vault and deployed
+- OAuth token stored in `~/.config/gphotos-sync/` after first auth
+- Cron job can be added via Ansible `cron` module
+
+---
+
+## Next Steps
+
+<!-- Add more setup steps below as you configure your system -->

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,0 +1,16 @@
+---
+- name: Configure Fedora workstation
+  hosts: local
+  become: true
+
+  tasks:
+    - name: Install pipx
+      dnf:
+        name: pipx
+        state: present
+
+    - name: Install gphotos-sync via pipx
+      become: false
+      command: pipx install gphotos-sync
+      args:
+        creates: ~/.local/bin/gphotos-sync


### PR DESCRIPTION
## Summary
- Install pipx and gphotos-sync via Ansible
- Document post-installation steps for Google API setup and authentication

## Test plan
- [ ] Run playbook on fresh Fedora install
- [ ] Verify gphotos-sync is installed (`gphotos-sync --help`)
- [ ] Test authentication with Google account
- [ ] Verify photo sync works

🤖 Generated with [Claude Code](https://claude.com/claude-code)