### PR TITLE
waybar: hide VPN modules when disconnected + f5fpc status popup

### DIFF
--- a/waybar/.config/waybar/config
+++ b/waybar/.config/waybar/config
@@ -251,7 +251,7 @@
         "format": "{icon}",
         "format-icons": {
             "connected": " 󰛳 󰕥 ",
-            "stopped": " 󰛳  "
+            "stopped": ""
         },
         "return-type": "json",
         "on-click": "~/.config/waybar/scripts/toggle-float.sh tsui-float kitty --class tsui-float tsui",
@@ -264,9 +264,10 @@
         "format": "{icon}",
         "format-icons": {
             "connected": " 󰖂 󰕥 ",
-            "stopped": " 󰖂  "
+            "stopped": ""
         },
         "return-type": "json",
+        "on-click": "~/.config/waybar/scripts/f5fpc.sh --popup",
         "on-click-right": "exec ~/.config/waybar/scripts/f5fpc.sh --toggle"
     },
 

--- a/waybar/.config/waybar/scripts/f5fpc.sh
+++ b/waybar/.config/waybar/scripts/f5fpc.sh
@@ -20,6 +20,38 @@ toggle_status() {
   fi
 }
 
+# Toggle a floating popup window showing live f5fpc status, positioned just
+# below the bar on the right edge (matching the btop popup style).
+show_popup() {
+  local title="waybar-f5"
+  local win_w=760 win_h=460 bar_height=52
+
+  if hyprctl clients -j | jq -e ".[] | select(.title == \"$title\")" >/dev/null 2>&1; then
+    hyprctl dispatch closewindow "title:$title"
+    return 0
+  fi
+
+  local screen_w pos_x pos_y
+  screen_w=$(hyprctl monitors -j | jq '.[0].width')
+  pos_x=$((screen_w - win_w - 12))
+  pos_y=$bar_height
+
+  kitty \
+    --title "$title" \
+    --override "initial_window_width=${win_w}" \
+    --override "initial_window_height=${win_h}" \
+    sh -c 'if command -v watch >/dev/null 2>&1; then exec watch -t -n 2 "f5fpc --info || echo \"f5fpc (VRT): not connected\""; fi; f5fpc --info || echo "f5fpc (VRT): not connected"; echo; read -n1 -s -r -p "Press any key to close..."' &
+
+  for _ in $(seq 1 20); do
+    sleep 0.1
+    if hyprctl clients -j | jq -e ".[] | select(.title == \"$title\")" >/dev/null 2>&1; then
+      hyprctl dispatch setfloating "title:$title"
+      hyprctl dispatch movewindowpixel "exact ${pos_x} ${pos_y}" "title:$title"
+      break
+    fi
+  done
+}
+
 case $1 in
 --status)
   info=$(f5_info)
@@ -28,7 +60,7 @@ case $1 in
     ip=$(grep -i "Tunnel Client IPv4 Address:" <<<"$info" | head -1 | sed -E 's/.*Address:[[:space:]]*//' | tr -d '[:space:]')
     server=$(grep -i "Tunnel Server IPv4 Address:" <<<"$info" | head -1 | sed -E 's/.*Address:[[:space:]]*//' | tr -d '[:space:]')
 
-    tip="F5 VPN: connected"
+    tip="f5fpc (VRT): connected"
     [ -n "$fav" ] && tip+=$'\n'"Favorite: $fav"
     [ -n "$ip" ] && tip+=$'\n'"Client IP: $ip"
     [ -n "$server" ] && tip+=$'\n'"Server IP: $server"
@@ -36,10 +68,13 @@ case $1 in
     jq -nc --arg tip "$tip" \
       '{"text":"connected","class":"connected","alt":"connected","tooltip":$tip}'
   else
-    jq -nc '{"text":"stopped","class":"stopped","alt":"stopped","tooltip":"F5 VPN: not connected"}'
+    jq -nc '{"text":"","class":"stopped","alt":"stopped","tooltip":"f5fpc (VRT): not connected"}'
   fi
   ;;
 --toggle)
   toggle_status
+  ;;
+--popup)
+  show_popup
   ;;
 esac

--- a/waybar/.config/waybar/scripts/tailscale.sh
+++ b/waybar/.config/waybar/scripts/tailscale.sh
@@ -133,7 +133,7 @@ case $1 in
 
     exitnode=$(jq -r '.Peer[]? | select(.ExitNode == true).DNSName | split(".")[0]' <<<"$status_json")
 
-    jq -nc --arg txt " exit-node: ${exitnode:-none}" --arg tip "Tailnet: ""$tailnet"$'\n\n'"$self"$'\n'"$peers" \
+    jq -nc --arg txt " exit-node: ${exitnode:-none}" --arg tip "Tailscale"$'\n'"Tailnet: ""$tailnet"$'\n\n'"$self"$'\n'"$peers" \
       '{"text": $txt, "class": "connected", "alt": "connected", "tooltip": $tip}'
   else
     echo "{\"text\":\"\",\"class\":\"stopped\",\"alt\":\"stopped\", \"tooltip\": \"The VPN is not active.\"}"


### PR DESCRIPTION
## Summary
Reworks the two Waybar VPN indicators (`custom/ts` Tailscale, `custom/f5` f5fpc/VRT).

- **Hidden when not connected** — both modules now output empty `text`/icon in the stopped state, so Waybar hides them instead of showing an idle icon.
- **Service name on hover** — tooltips now lead with the service name (`Tailscale`, `f5fpc (VRT)`).
- **f5 status popup** — left-clicking the f5 module opens a floating popup window showing live `f5fpc --info`, positioned just under the bar on the right edge (same style as the btop popup). Toggles closed on second click.

## Files
- `waybar/.config/waybar/config` — icons/text for stopped state, f5 `on-click`
- `waybar/.config/waybar/scripts/f5fpc.sh` — empty stopped text, renamed tooltip, new `--popup` action
- `waybar/.config/waybar/scripts/tailscale.sh` — service name in tooltip

## Testing
- `bash -n` on both scripts, JSON config validated
- Status scripts produce expected JSON; Waybar reloaded live via SIGUSR2